### PR TITLE
Fix/admin invoice show

### DIFF
--- a/app/views/admin_invoices/show.html.erb
+++ b/app/views/admin_invoices/show.html.erb
@@ -1,7 +1,7 @@
 <h1>Invoice: #<%= @invoice.id %></h1>
 <ul>
   <li>Status: <%= @invoice.status%></li>
-  <li>Created at: <%= @invoice.created_at.strftime("%A %b %M %Y") %></li>
+  <li>Created at: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %></li>
   <li>Total Revenue: $<%= ('%.2f' % @invoice.total_revenue.fdiv(100)) %></li>
   <li> Customer Name: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></li>
 </ul>

--- a/app/views/admin_invoices/show.html.erb
+++ b/app/views/admin_invoices/show.html.erb
@@ -9,7 +9,7 @@
 <% @invoice.invoice_items.each do |ii| %></p>
       <p>Item: <%= ii.item.name %></p>
       <p>Quantity ordered: <%= ii.quantity %></p>
-      <p>Unit price: <%= ii.unit_price %></p>
+      <p>Unit price: $<%= ('%.2f' % ii.unit_price.fdiv(100)) %></p>
       <p>Status: <%= ii.status %></p>
     <% end %>
 

--- a/app/views/admin_invoices/show.html.erb
+++ b/app/views/admin_invoices/show.html.erb
@@ -7,9 +7,9 @@
 </ul>
 
 <% @invoice.invoice_items.each do |ii| %></p>
-      <p>Item: <%= ii.item.name %></p>
-      <p>Quantity ordered: <%= ii.quantity %></p>
-      <p>Unit price: $<%= ('%.2f' % ii.unit_price.fdiv(100)) %></p>
-      <p>Status: <%= ii.status %></p>
-    <% end %>
+  <p>Item: <%= ii.item.name %></p>
+  <p>Quantity ordered: <%= ii.quantity %></p>
+  <p>Unit price: $<%= ('%.2f' % ii.unit_price.fdiv(100)) %></p>
+  <p>Status: <%= ii.status %></p>
+ <% end %>
 

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'Admin invoices show page' do
     visit "/admin/invoices/#{@invoice_1.id}"
     expect(page).to have_content("Two-Leg Pantaloons")
     expect(page).to have_content("Quantity ordered: 1")
-    expect(page).to have_content(5000)
+    expect(page).to have_content("Unit price: $50.00")
     expect(page).to have_content("shipped")
   end
   

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'Admin invoices show page' do
     InvoiceItem.create!(item_id: item_1.id, invoice_id: @invoice_1.id, quantity: 3, unit_price: item_1.unit_price, status: 2)
     visit "/admin/invoices/#{@invoice_1.id}"
 
-    expect(page).to have_content("Total Revenue: $104.97")
+    expect(page).to have_content("Total Revenue: $154.97")
   end
 end
 


### PR DESCRIPTION
Adjust date formatting and total revenue test for admin invoice show page. Format unit price on admin invoice show page to be in dollars.